### PR TITLE
Max fixes and a new option

### DIFF
--- a/AwardData/AwardData.csproj
+++ b/AwardData/AwardData.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
 
-  <ItemGroup>    
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="3.1.0" />    
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="3.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/AwardWeb/Properties/launchSettings.json
+++ b/AwardWeb/Properties/launchSettings.json
@@ -21,15 +21,7 @@
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
-        "applicationUrl": "http://localhost:56081"
-      },
-      "AwardWeb Prod": {
-        "commandName": "Project",
-        "launchBrowser": true,
-        "environmentVariables": {
-          "ASPNETCORE_ENVIRONMENT": "Production"
-        },
-        "applicationUrl": "http://localhost:56080"
-      }
+      "applicationUrl": "http://localhost:56081"
     }
+  }
 }

--- a/FlysasClient/ConsoleClient.cs
+++ b/FlysasClient/ConsoleClient.cs
@@ -29,11 +29,11 @@ namespace FlysasClient
         public async System.Threading.Tasks.Task InputLoop()
         {
             string input = null;
+            txtOut.WriteLine("Syntax: Origin-Destination outDate [inDate]");
             while (!nameof(Commands.Quit).Equals(input, StringComparison.OrdinalIgnoreCase))
             {
-                txtOut.WriteLine("Syntax: Origin-Destination outDate [inDate]");
-                txtOut.Write(">>");
-                input = txtIn.ReadLine();
+                input = ReadLine.Read("FS> ");
+                ReadLine.AddHistory(input);
                 await Run(input);
             }
         }
@@ -53,40 +53,56 @@ namespace FlysasClient
                     }
                     catch (ParserException ex)
                     {
-                        txtOut.Write("Syntax error:" + ex.Message);
+                        txtOut.WriteLine("Syntax error:" + ex.Message);
                     }
                     catch
                     {
-                        txtOut.Write("Syntax error:");
+                        txtOut.WriteLine("Syntax error:");
                     }
                     if (req != null)
                     {
-                        SearchResult result = null;
-                        try
+                        DateTime OutDate = (DateTime)req.OutDate;
+                        var outDates = System.Linq.Enumerable.Range(0, options.days).Select(i => OutDate.AddDays(i)).ToList();
+                        List<DateTime> inDates = null;
+                        if (req.InDate.HasValue)
                         {
-                            result = await client.SearchAsync(req);
+                            DateTime InDate = (DateTime)req.InDate;
+                            inDates = System.Linq.Enumerable.Range(0, options.days).Select(i => InDate.AddDays(i)).ToList();
                         }
-                        catch
+                        for (var idx = 0; idx < options.days; idx++)
                         {
-                            txtOut.WriteLine("Error");
-                        }
-                        if (result != null)
-                        {
-                            if (result.errors != null && result.errors.Any())
-                                txtOut.WriteLine("flysas.com says: " + result.errors.First().errorMessage);
-                            else
+                            req.OutDate = outDates[idx];
+                            if (req.InDate.HasValue)
                             {
-                                var printer = new TablePrinter(txtOut);
-                                txtOut.WriteLine("*********Outbound*******");
-                                printer.PrintFlights(result.outboundFlights, options, req.From, req.To);
-                                if (req.InDate.HasValue)
+                                req.InDate = inDates[idx];
+                            }
+                            SearchResult result = null;
+                            try
+                            {
+                                result = await client.SearchAsync(req);
+                            }
+                            catch
+                            {
+                                txtOut.WriteLine("Error");
+                            }
+                            if (result != null)
+                            {
+                                if (result.errors != null && result.errors.Any())
+                                    txtOut.WriteLine("flysas.com says: " + result.errors.First().errorMessage);
+                                else
                                 {
-                                    txtOut.WriteLine("*********Inbound*******");
-                                    printer.PrintFlights(result.inboundFlights, options, req.To, req.From);
+                                    var printer = new TablePrinter(txtOut);
+                                    txtOut.WriteLine("********* Outbound " + outDates[idx].ToShortDateString() + " *******");
+                                    printer.PrintFlights(result.outboundFlights, options, req.From, req.To);
+                                    if (req.InDate.HasValue)
+                                    {
+                                        txtOut.WriteLine("********* Inbound " + inDates[idx].ToShortDateString() + " *******");
+                                        printer.PrintFlights(result.inboundFlights, options, req.To, req.From);
+                                    }
                                 }
                             }
+                            txtOut.Write(Environment.NewLine + Environment.NewLine);
                         }
-                        txtOut.Write(Environment.NewLine + Environment.NewLine);
                     }
                 }
             }

--- a/FlysasClient/ConsoleClient.cs
+++ b/FlysasClient/ConsoleClient.cs
@@ -33,8 +33,11 @@ namespace FlysasClient
             while (!nameof(Commands.Quit).Equals(input, StringComparison.OrdinalIgnoreCase))
             {
                 input = ReadLine.Read("FS> ");
-                ReadLine.AddHistory(input);
-                await Run(input);
+                if (input != "")
+                {
+                    ReadLine.AddHistory(input);
+                    await Run(input);
+                }
             }
         }
 

--- a/FlysasClient/FlysasClient.csproj
+++ b/FlysasClient/FlysasClient.csproj
@@ -30,6 +30,7 @@
   <ItemGroup>    
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.0" />
     <PackageReference Include="Microsoft.NETCore.DotNetHostPolicy" Version="3.1.0" />    
+    <PackageReference Include="ReadLine" Version="2.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/FlysasClient/Options.cs
+++ b/FlysasClient/Options.cs
@@ -39,6 +39,14 @@ namespace FlysasClient
                         prop.SetValue(this, myBool(value));
                     if (prop.PropertyType == typeof(string))
                         prop.SetValue(this, value);
+                    if (prop.PropertyType == typeof(int))
+                    {
+                        int intVal;
+                        if (int.TryParse(value, System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out intVal))
+                            prop.SetValue(this, intVal);
+                        else
+                            return false;
+                    }
                     if (prop.PropertyType.IsEnum)
                     {
                         object enumVal = null;
@@ -87,6 +95,8 @@ namespace FlysasClient
     }
     public class Options : OptionsParser
     {
+        [OptionParser("days")]
+        public int days { get; private set; } = 1;
         [OptionParser("bookingclass")]
         public bool OutputBookingClass { get; private set; } = false;
         [OptionParser("equipment")]

--- a/FlysasClient/appsettings.json
+++ b/FlysasClient/appsettings.json
@@ -4,6 +4,6 @@
   "bookingclass": false,
   "equipment": false,
   "flightnumber": true,
-  "mode": "star", //star, points
+  "mode": "star", //star, points, revenue
   "days": 1
 }

--- a/FlysasClient/appsettings.json
+++ b/FlysasClient/appsettings.json
@@ -5,5 +5,5 @@
   "equipment": false,
   "flightnumber": true,
   "mode": "star", //star, points
-  "days": 7
+  "days": 1
 }

--- a/FlysasClient/appsettings.json
+++ b/FlysasClient/appsettings.json
@@ -4,5 +4,6 @@
   "bookingclass": false,
   "equipment": false,
   "flightnumber": true,
-  "mode": "REVENUE" //star, points
+  "mode": "star", //star, points
+  "days": 7
 }

--- a/FlysasLib/FlysasLib.csproj
+++ b/FlysasLib/FlysasLib.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/OpenFlightsData/Airline.cs
+++ b/OpenFlightsData/Airline.cs
@@ -26,7 +26,7 @@ namespace OpenFlightsData
                     var cols = mySplit(row);
                     var a = new Airline
                     {
-                        ID = int.Parse(cols[0]),
+                        ID = int.Parse(cols[0], System.Globalization.CultureInfo.InvariantCulture),
                         Name = cols[1],
                         Alias = cols[2],
                         IATA = cols[3],

--- a/OpenFlightsData/OpenFlightsData.csproj
+++ b/OpenFlightsData/OpenFlightsData.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.3</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <Content Include="data\airlines.dat">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/README.md
+++ b/README.md
@@ -6,13 +6,18 @@ Fix for running on Mac and added an option to specify number of days to search f
 set days 7
 
 Selecting search mode:
+
 set mode points (SAS points)
+
 set mode star (Star Alliance points)
+
 set mode revenue (SAS revenue)
 
 Searching one way:
+
 arn-osl 24/12
 
 Searching return:
+
 arn-osl 24/12 25/12
 

--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@ Console app for searching tickets with Scandinavian Airlines. Both reward and re
 
 Fix for running on Mac and added an option to specify number of days to search for (default 1):
 
-set mode days 7
+set days 7

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # flysasClient
 Console app for searching tickets with Scandinavian Airlines. Both reward and revenue are supported.
 
-More info @ https://travelhacks.azurewebsites.net/Console
+Fix for running on Mac and added an option to specify number of days to search for (default 1):
 
-# AwardWeb
-Site for searching award tickets with SAS and Star Alliance. Its running at https://awardhacks.se
+set mode days 7

--- a/README.md
+++ b/README.md
@@ -4,3 +4,15 @@ Console app for searching tickets with Scandinavian Airlines. Both reward and re
 Fix for running on Mac and added an option to specify number of days to search for (default 1):
 
 set days 7
+
+Selecting search mode:
+set mode points (SAS points)
+set mode star (Star Alliance points)
+set mode revenue (SAS revenue)
+
+Searching one way:
+arn-osl 24/12
+
+Searching return:
+arn-osl 24/12 25/12
+

--- a/publish.sh
+++ b/publish.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+dotnet publish -c Release --self-contained -r osx-x64 -f netcoreapp3.1


### PR DESCRIPTION
There are two Mac specific fixes, a oneliner about converting a string to integer which would fail on Mac if integer was negative. The second fix is a new ReadLine lib to support arrow up in the console which doesn't work with the default one on Mac. The new option is for searching a range of dates with the option 'days' (default to 1).